### PR TITLE
Replace mod() with % operator

### DIFF
--- a/combobreaker.ino
+++ b/combobreaker.ino
@@ -58,9 +58,6 @@
 // Number of digits on a Master combo lock
 #define DIGITS 40
 
-// C's % is remainder instead of modulo
-#define mod(a, b) ((a % b + b) % b)
-
 // For debug
 #define BAUDRATE 9600
 
@@ -317,7 +314,7 @@ void spinto(int spins, int digit, boolean cw)
   else
     digit = digit - current_digit;
 
-  digit = mod(digit, DIGITS);
+  digit = digit % DIGITS;
 
   // track where we are for next time
   current_digit = tmp;
@@ -368,7 +365,7 @@ void step(int steps)
   if (newPosition != oldPosition)
   {
     //      oldPosition = newPosition;
-    oldPosition = mod(newPosition, ENCODER_STEPS);//XXX
+    oldPosition = newPosition % ENCODER_STEPS;//XXX
     Serial.print("newpos=");
     Serial.print(newPosition);
     Serial.print(" actual=");


### PR DESCRIPTION
The expression `((a % b + b) % b)` turns out to be equivalent to `(a % b)`. This could be algebraically proven, but as a more intuitive example I've included some C code:
```
#include <stdio.h>

#define mod(a, b) ((a % b + b) % b)

int main() {
    int max = 100;
    for (int i = 1; i <= max; i++) {
        int m1 = max % i;
        int m2 = mod(max, i);
        if (m1 != m2) {
            printf("%d != %d\n", m1, m2);
            return -1;
        }
        printf("%d %% %d = %d; mod(%d, %d) = %d\n", max, i, m1, max, i, m2);
    }
}
```